### PR TITLE
Capture and use current buffer upon invocation

### DIFF
--- a/counsel-jq.el
+++ b/counsel-jq.el
@@ -14,9 +14,8 @@
   "Call 'jq' with the QUERY with a default of '.'."
   (with-current-buffer
       ;; The user entered the `counsel-jq` query in the minibuffer.
-      ;; This expression uses the most recent other buffer (see
-      ;; https://www.gnu.org/software/emacs/manual/html_node/eintr/Switching-Buffers.html#fnd-2).
-      (other-buffer (current-buffer) t)
+      ;; This expression uses the most recent buffer ivy-read was invoked from
+      (ivy-state-buffer ivy-last)
     (call-process-region
      (point-min)
      (point-max)

--- a/counsel-jq.el
+++ b/counsel-jq.el
@@ -14,7 +14,8 @@
   "Call 'jq' with the QUERY with a default of '.'."
   (with-current-buffer
       ;; The user entered the `counsel-jq` query in the minibuffer.
-      ;; This expression uses the most recent buffer ivy-read was invoked from
+      ;; This expression uses the most recent buffer ivy-read was
+      ;; invoked from.
       (ivy-state-buffer ivy-last)
     (call-process-region
      (point-min)


### PR DESCRIPTION
Fixes #3 

This pull request updates `counsel-jq` to capture the current buffer upon invocation and subsequently uses that buffer to evaluate it's jq queries against. Using this method always guarantees that the buffer that was selected when the command was executed is the one that queries are evaluated against.